### PR TITLE
Port b1 command from python bot

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -173,7 +173,7 @@ export const Api = Object.freeze({
 
   IMAGE_TOOLS_BACKGROUND_REMOVE:
     '/image/tools/background/remove',
-    IMAGE_TOOLS_OBJECT_REMOVE:
+  IMAGE_TOOLS_OBJECT_REMOVE:
     '/image/tools/object/remove',
   IMAGE_TOOLS_CONVERT:
     '/image/tools/convert',
@@ -304,6 +304,9 @@ export const Api = Object.freeze({
 
 export const CDN = Tools.URIEncodeWrap({
   URL: Domains.CDN,
+
+  COMMAND_ASSETS_B1:
+    '/command-assets/b1.png',
 
   EMOJIS_APPLE: (codepoint: string) =>
     `/emojis/apple/128x128/${codepoint}.png`,

--- a/src/commands/prefixed/fun/b1.ts
+++ b/src/commands/prefixed/fun/b1.ts
@@ -1,0 +1,33 @@
+import { Command, CommandClient } from 'detritus-client';
+
+import { CommandCategories } from '../../../constants';
+import { editOrReply } from '../../../utils';
+
+import { BaseCommand } from '../basecommand';
+
+
+export const COMMAND_NAME = 'b1';
+
+export default class B1Command extends BaseCommand {
+    constructor(client: CommandClient) {
+        super(client, {
+            name: COMMAND_NAME,
+
+            metadata: {
+                description: 'cool',
+                examples: [
+                    COMMAND_NAME,
+                ],
+                category: CommandCategories.FUN,
+                usage: '',
+            },
+        });
+    }
+
+    async run(context: Command.Context) {
+        return editOrReply(
+            context,
+            'https://cdn.discordapp.com/attachments/560593452476399626/716571699247579186/b1.png',
+        );
+    }
+}

--- a/src/commands/prefixed/fun/b1.ts
+++ b/src/commands/prefixed/fun/b1.ts
@@ -1,5 +1,6 @@
 import { Command, CommandClient } from 'detritus-client';
 
+import { CDN } from '../../../api/endpoints';
 import { CommandCategories } from '../../../constants';
 import { editOrReply } from '../../../utils';
 
@@ -27,7 +28,7 @@ export default class B1Command extends BaseCommand {
     async run(context: Command.Context) {
         return editOrReply(
             context,
-            'https://cdn.discordapp.com/attachments/560593452476399626/716571699247579186/b1.png',
+            CDN.COMMAND_ASSETS_B1,
         );
     }
 }


### PR DESCRIPTION
Port b1 command from Fun category: https://github.com/NotSoSuper/NotSoBot/blob/7ae4a174b4e38b5c380ad7e69ebadf049d67a325/mods/Fun.py#L1434-L1438

This command is essential for NotSoBot lore.

The only problem is that old command uploaded local file. I don't think newer version has it, so I need help with where to get it from now. Currently it points to one of the previous b1 invocations and will stop working if something happens to that message or channel.